### PR TITLE
Update copyright years

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2018 The ISC Authors. 
+Copyright (c) 2016-2020 The ISC Authors.
 
 All rights reserved.
 

--- a/include/header.hpp
+++ b/include/header.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Your Name <your_email>
+// Copyright 2020 Your Name <your_email>
 
 #ifndef INCLUDE_HEADER_HPP_
 #define INCLUDE_HEADER_HPP_

--- a/sources/source.cpp
+++ b/sources/source.cpp
@@ -1,3 +1,3 @@
-// Copyright 2018 Your Name <your_email>
+// Copyright 2020 Your Name <your_email>
 
 #include <header.hpp>

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Your Name <your_email>
+// Copyright 2020 Your Name <your_email>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
This simply changes `2018` to `2020` in copyright-related contexts.