### PR TITLE
Fixed CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,4 +58,4 @@ jobs:
               git submodule update --init
       - name: quality
         run:
-          docker run --env-file .env -v `pwd`:`pwd` -w `pwd` -t rusdevops/bootstrap-cpp scripts/coverage.sh
+          docker run -v `pwd`:`pwd` -w `pwd` -t rusdevops/bootstrap-cpp scripts/coverage.sh


### PR DESCRIPTION
Проверки не запустятся, если не убрать флаг `--env-file`.

Без него все прекрасно.