### PR TITLE
Refactor shell scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ jobs:
         - docker run -v `pwd`:`pwd` -w `pwd` -t rusdevops/bootstrap-cpp scripts/tests.sh
     - name: "quality"
       script:
-        - ./scripts/genenv.sh
-        - docker run --env-file .env -v `pwd`:`pwd` -w `pwd` -t rusdevops/bootstrap-cpp scripts/coverage.sh
+        - docker run -v `pwd`:`pwd` -w `pwd` -t rusdevops/bootstrap-cpp scripts/coverage.sh
       # The bot has gone...
       # - docker run --env-file .env -v `pwd`:`pwd` -w `pwd` -t rusdevops/bootstrap-cpp scripts/duplication.sh
 

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -5,8 +5,7 @@ set -e
 declare -r FILTER=-build/c++11,-runtime/references,\
 -whitespace/braces,-whitespace/indent,-whitespace/comments,-build/include_order
 
-find ./include/ ./scripts/ ./sources/ -name "*.cpp" -or -name "*.hpp" -or -name ".h" | grep -v "./tools/*"\
-| xargs cpplint --filter=$FILTER
+find ./include/ ./scripts/ ./sources/ -name "*.cpp" -or -name "*.hpp" -or -name ".h" | xargs -0 cpplint --filter=$FILTER
 
 export CTEST_OUTPUT_ON_FAILURE=true
 # address sanitizer

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -e
 
 files=`find . -name "*.cpp" -or -name "*.hpp" -or -name ".h" | grep -v "./tools/*"`

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-readonly FILTER=-build/c++11,-runtime/references,\
+declare -r FILTER=-build/c++11,-runtime/references,\
 -whitespace/braces,-whitespace/indent,-whitespace/comments,-build/include_order
 
 find ./include/ ./scripts/ ./sources/ -name "*.cpp" -or -name "*.hpp" -or -name ".h" | grep -v "./tools/*"\

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -2,9 +2,11 @@
 
 set -e
 
-files=`find . -name "*.cpp" -or -name "*.hpp" -or -name ".h" | grep -v "./tools/*"`
-filter=-build/c++11,-runtime/references,-whitespace/braces,-whitespace/indent,-whitespace/comments,-build/include_order
-echo $files | xargs cpplint --filter=$filter
+readonly FILTER=-build/c++11,-runtime/references,\
+-whitespace/braces,-whitespace/indent,-whitespace/comments,-build/include_order
+
+find ./include/ ./scripts/ ./sources/ -name "*.cpp" -or -name "*.hpp" -or -name ".h" | grep -v "./tools/*"\
+| xargs cpplint --filter=$FILTER
 
 export CTEST_OUTPUT_ON_FAILURE=true
 # address sanitizer

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 export GTEST_COLOR=1

--- a/scripts/genenv.sh
+++ b/scripts/genenv.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+echo "TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG" > .env
+echo "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST" >> .env
+echo "TRAVIS_BRANCH=$TRAVIS_BRANCH" >> .env
+echo "TRAVIS_COMMIT=$TRAVIS_COMMIT" >> .env

--- a/scripts/genenv.sh
+++ b/scripts/genenv.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -e
-
-echo "TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG" > .env
-echo "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST" >> .env
-echo "TRAVIS_BRANCH=$TRAVIS_BRANCH" >> .env
-echo "TRAVIS_COMMIT=$TRAVIS_COMMIT" >> .env

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -e
 export GTEST_COLOR=1
 CMAKE_LINKER_OPTS="-DCMAKE_EXE_LINKER='-fuse-ld=gold'"


### PR DESCRIPTION
- [x] Используется shebang `#!/usr/bin/env bash` вместо `#!/usr/bin bash`
- [x] `checks.sh` теперь сканирует только директории с исходниками, указанными в проекте (раньше запуск скрипта на локальной машине сканировал также все сгенерированные директории)
- [x] убран параметр `--env-file`, который полагался на файл `.env`, генерировавшийся `genenv.sh`, который был удалён в be82e9f7e4bb35e50e5323b1fb5ec68ff9b1a0c7