### PR TITLE
Linter bug fix.

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -5,7 +5,7 @@ set -e
 declare -r FILTER=-build/c++11,-runtime/references,\
 -whitespace/braces,-whitespace/indent,-whitespace/comments,-build/include_order
 
-find ./include/ ./scripts/ ./sources/ -name "*.cpp" -or -name "*.hpp" -or -name ".h" | xargs -0 cpplint --filter=$FILTER
+find ./include/ ./scripts/ ./sources/ -name "*.cpp" -or -name "*.hpp" -or -name ".h" | xargs cpplint --filter=$FILTER
 
 export CTEST_OUTPUT_ON_FAILURE=true
 # address sanitizer


### PR DESCRIPTION
Fixed a bug that prevented the linter from checking code files.
While xargs has been used with -0 argument all sources was skipped with error "Can't open for reading". Removing this flag solved this.

![image](https://user-images.githubusercontent.com/23170909/108475911-6d5cd180-72a2-11eb-9f1e-4851ad1cf3e9.png)

