### PR TITLE
macOS support for memory safety checks

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -11,10 +11,17 @@ export CTEST_OUTPUT_ON_FAILURE=true
 # address sanitizer
 #CMAKE_LINKER_OPTS="-DCMAKE_EXE_LINKER='-fuse-ld=gold'"
 CMAKE_CONFIG_OPTS="-DHUNTER_CONFIGURATION_TYPES=Debug -DCMAKE_BUILD_TYPE=Debug"
-CMAKE_TOOLCHAIN_OPTS="-DCMAKE_TOOLCHAIN_FILE='$(pwd)/tools/polly/sanitize-address-cxx17-pic.cmake'"
+if [[ ! "$OSTYPE" == "darwin"* ]]; then
+  CMAKE_TOOLCHAIN_OPTS="-DCMAKE_TOOLCHAIN_FILE='tools/polly/sanitize-address-cxx17-pic.cmake'"
+fi
 CMAKE_OPTS="$CMAKE_LINKER_OPTS $CMAKE_CONFIG_OPTS $CMAKE_TOOLCHAIN_OPTS"
 cmake -H. -B_builds/sanitize-address-cxx17 $CMAKE_OPTS
 cmake --build _builds/sanitize-address-cxx17
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  source scripts/macos_leak_check.sh
+  macos_leak_check ./_builds/sanitize-address-cxx17/tests ./_builds/sanitize-address-cxx17/tests.memgraph
+  exit
+fi
 ./_builds/sanitize-address-cxx17/tests
 # thread sanitizer
 CMAKE_TOOLCHAIN_OPTS="-DCMAKE_TOOLCHAIN_FILE='$(pwd)/tools/polly/sanitize-thread-cxx17-pic.cmake'"

--- a/scripts/macos_leak_check.sh
+++ b/scripts/macos_leak_check.sh
@@ -1,0 +1,15 @@
+# Run leaks util from Xcode on compiled binary
+# We cannot just pass the binary to leaks, as it will not output graphs with that option
+# instead, we start the binary and attach to it, take it's memory snapshot and output that as a graph
+# It is also possible to attach a debugger at this point for any reason should it become necessary
+# ARGUMENTS:
+#     Path to binary
+#     Output memgraph path
+macos_leak_check() {
+  MallocScribble=1 MallocStackLogging=1 MallocStackLoggingNoCompact=1 MallocStackLogging=1 MallocStackLoggingNoCompact=1 $1 --gtest_also_run_disabled_tests & TEST_PID=$!
+  # wait for all the tests to finish and the code to get stuck in permaloop disabled test
+  # is signaling this script possible from code somehow without busy waiting?
+  sleep 1
+  leaks --outputGraph $2 $TEST_PID
+  kill $TEST_PID
+}

--- a/tests/example.cpp
+++ b/tests/example.cpp
@@ -1,6 +1,7 @@
 // Copyright 2021 Your Name <your_email>
 
 #include <stdexcept>
+#include <thread>
 
 #include <gtest/gtest.h>
 
@@ -8,4 +9,8 @@
 
 TEST(Example, EmptyTest) {
     EXPECT_THROW(example(), std::runtime_error);
+}
+
+TEST(DISABLED_Snapshot, Speen) {
+  for (;;) std::this_thread::yield();
 }


### PR DESCRIPTION
It still lacks the functionality of TSAN, but I don't currently know of any way to do that. Even docker images fail at TSAN, so there's a possibility it's restricted by some low level memory model incompatibility.
This, as far as I know is the only way of detecting memory leaks, buffer overflows and stack smashing (besides process being killed) on macOS. I am considering any sort of virtual machine, including Docker, "not macOS" for pretty obvious reasons of being literally a virtual machine and a heavy memory hog