### PR TITLE
workflow: run on self-hosted runner

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   Checks:
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Запуск воркфлоу на self-hosted. Необходимо для Сибири, для того чтобы справиться с нагрузкой