### PR TITLE
cpplint: ignore build/include_subdir

### DIFF
--- a/scripts/codestyle.sh
+++ b/scripts/codestyle.sh
@@ -5,7 +5,7 @@ pushd $(git rev-parse --show-toplevel)
 set -e
 
 declare -r FILTER=-build/c++11,-runtime/references,\
--whitespace/braces,-whitespace/indent,-whitespace/comments,-build/include_order
+-whitespace/braces,-whitespace/indent,-whitespace/comments,-build/include_order,-build/include_subdir
 
 find ./include/ ./scripts/ ./sources/ -name "*.cpp" -or -name "*.hpp" -or -name ".h" | xargs python3 -m cpplint --filter=$FILTER
 


### PR DESCRIPTION
this allows to include headers with "" instead of <>